### PR TITLE
Closes #99: MEGA IPA url support

### DIFF
--- a/.github/workflows/ipa.yml
+++ b/.github/workflows/ipa.yml
@@ -145,17 +145,21 @@ jobs:
         with:
           exclude_inputs: bundle_id,display_name,youpip,ytuhd,ryd,abconfig,youquality,youspeed,youmute,youloop,ytweaks,youslider,ytholdspeed,youchoose,youshare,gonerino,getcap,demc,ytshare,volboost
           
-      - name: action-megacmd
-        if: ${{ startsWith(inputs.ipa_url, 'https://mega.nz/file/') }}
-        uses: Difegue/action-megacmd@1.4.0
-
+      - name: Install MEGA downloader
+        if: ${{ startsWith(inputs.ipa_url, 'https://mega.nz/') }}
+        run: brew install megatools
       - name: Download IPA from Mega share link
-        if: ${{ startsWith(inputs.ipa_url, 'https://mega.nz/file/') }}
-        run: mega-get "${{ inputs.ipa_url }}" youtube.ipa
-
+        if: ${{ startsWith(inputs.ipa_url, 'https://mega.nz/') }}
+        env:
+          IPA_URL: ${{ inputs.ipa_url }}
+        run: |
+          megadl --no-progress --path youtube.ipa "$IPA_URL"
       - name: Download IPA from direct URL
-        if: ${{ !startsWith(inputs.ipa_url, 'https://mega.nz/file/') }}
-        run: wget "${{ inputs.ipa_url }}" --quiet --no-verbose -O youtube.ipa
+        if: ${{ !startsWith(inputs.ipa_url, 'https://mega.nz/') }}
+        env:
+          IPA_URL: ${{ inputs.ipa_url }}
+        run: |
+          wget "$IPA_URL" --quiet --no-verbose -O youtube.ipa
 
       - name: Validate IPA
         run: |

--- a/.github/workflows/ipa.yml
+++ b/.github/workflows/ipa.yml
@@ -145,10 +145,20 @@ jobs:
         with:
           exclude_inputs: bundle_id,display_name,youpip,ytuhd,ryd,abconfig,youquality,youspeed,youmute,youloop,ytweaks,youslider,ytholdspeed,youchoose,youshare,gonerino,getcap,demc,ytshare,volboost
           
-      - name: Download and Validate IPA
-        run: |
-          wget "${{ inputs.ipa_url }}" --quiet --no-verbose -O youtube.ipa
+      - name: action-megacmd
+        if: ${{ startsWith(inputs.ipa_url, 'https://mega.nz/file/') }}
+        uses: Difegue/action-megacmd@1.4.0
 
+      - name: Download IPA from Mega share link
+        if: ${{ startsWith(inputs.ipa_url, 'https://mega.nz/file/') }}
+        run: mega-get "${{ inputs.ipa_url }}" youtube.ipa
+
+      - name: Download IPA from direct URL
+        if: ${{ !startsWith(inputs.ipa_url, 'https://mega.nz/file/') }}
+        run: wget "${{ inputs.ipa_url }}" --quiet --no-verbose -O youtube.ipa
+
+      - name: Validate IPA
+        run: |
           file_type=$(file --mime-type -b youtube.ipa)
 
           if [[ "$file_type" != "application/x-ios-app" && "$file_type" != "application/zip" ]]; then


### PR DESCRIPTION
Closes #99

## Summary

Adds MEGA share-link support for the `ipa_url` input in the `Build IPA with tweaks` workflow.

## Changes

- Use `megatools` / `megadl` for `https://mega.nz/` links.
- Keep `wget` for direct-download URLs.
- Keep the downloaded file path as `youtube.ipa`.
- Keep validation and later build steps unchanged.

## Testing

Tested with a MEGA IPA link and a direct-download IPA URL.
MEGA path successful build:
https://github.com/Bryan0211/YouMod/actions/runs/27054780536
<img width="1173" height="801" alt="screenshot of successful MEGA build run" src="https://github.com/user-attachments/assets/b80ae1f8-75a9-4e00-bceb-49b060061ddf" />
