### PR TITLE
Fix fullscreen engagement panel on newer YouTube versions

### DIFF
--- a/Files/Player.x
+++ b/Files/Player.x
@@ -327,6 +327,14 @@ static void YouModAddEndTime(YTPlayerViewController *self, YTSingleVideoControll
 - (BOOL)replacePreviousPaddleWithRewindButtonForSingletonVods { return IS_ENABLED(ReplacePrevNextButtons) ? YES : %orig; }
 %end
 
+// Disable the newer fullscreen engagement overlay introduced in recent YouTube versions.
+// Keep the YTColdConfig hook above for older versions that use the A/B flag directly.
+%hook YTFullscreenEngagementOverlayController
+- (void)setEnabled:(BOOL)enabled {
+    %orig(IS_ENABLED(DisablesEngagementPanel) ? NO : enabled);
+}
+%end
+
 // No Endscreen Cards
 %hook YTCreatorEndscreenView
 - (void)setHidden:(BOOL)arg1 { 


### PR DESCRIPTION
## What changed

Recent YouTube versions use `YTFullscreenEngagementOverlayController` for the fullscreen recommendations/engagement overlay. The existing `YTColdConfig.isLandscapeEngagementPanelEnabled` hook remains in place for older versions, and this patch also forces the newer controller's `setEnabled:` setter off when the existing `DisablesEngagementPanel` preference is enabled.

This reuses the current **Disables engagement panel in fullscreen** setting. No new preference or localization is needed.

## Why

On YouTube 21.34.3, enabling the existing setting still allowed the swipe-up recommendations overlay to appear in fullscreen.

Discussion and cross-device comparison: [Issue #157](https://github.com/Tonwalter888/YouMod/issues/157).

## Validation

- Device: iPhone 16 Pro
- YouTube: 21.34.3
- YouMod: 2.0.0 plus this patch
- Result: the patched app launches successfully, and enabling **YouMod → Player → Disables engagement panel in fullscreen** blocks the swipe-up recommendations overlay.
- Build: [GitHub Actions run 33313208409](https://github.com/Noel-0/YouMod/actions/runs/33313208409)

The test IPA was built by replacing only `YouMod.dylib` in the working driftywinds IPA. This preserved the original bundle identifier and avoided duplicate tweak injection.

The additional controller hook follows the compatibility approach already used by [YTLitePlus](https://github.com/YTLitePlus/YTLitePlus/blob/main/YTLitePlus.xm).
