### PR TITLE
Add Go installation step to CI workflow

### DIFF
--- a/.github/workflows/ipa.yml
+++ b/.github/workflows/ipa.yml
@@ -148,6 +148,9 @@ jobs:
       - name: Install Dependencies
         run: brew install make ldid
 
+      - name: Install Go
+        run: brew install go
+
       - name: Set PATH Environment Variables
         run: |
           echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH


### PR DESCRIPTION
Fixed the job is failing because the go command is not installed on the macOS runner, causing the Makefile's before-all target to fail with exit code 127.